### PR TITLE
feat: create Registration service and controller

### DIFF
--- a/backend/codeplac/src/main/java/codeplac/codeplac/Controller/RegistrationController.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Controller/RegistrationController.java
@@ -1,10 +1,72 @@
 package codeplac.codeplac.Controller;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import codeplac.codeplac.Exception.Excecao;
+import codeplac.codeplac.Model.RegistrationModel;
+import codeplac.codeplac.Service.RegistrationService;
 
 @RestController
-@RequestMapping("/登记")
+@RequestMapping("/registration")
 public class RegistrationController {
 
+  @Autowired
+  RegistrationService registrationService;
+
+  @PostMapping("/create")
+  public ResponseEntity<RegistrationModel> criarInscricao(@RequestBody RegistrationModel registration) {
+    return new ResponseEntity<>(registrationService.createRegistration(registration), HttpStatus.CREATED);
+  }
+
+  @GetMapping("/list")
+  public ResponseEntity<List<RegistrationModel>> listarInscricoes() {
+    return new ResponseEntity<>(registrationService.getAllRegistrations(), HttpStatus.OK);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<RegistrationModel> obterInscricao(@PathVariable int id) {
+    try {
+      return new ResponseEntity<>(registrationService.getRegistrationById(id), HttpStatus.OK);
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+    }
+  }
+
+  @PutMapping("/modify/{id}")
+  public ResponseEntity<RegistrationModel> modificarInscricao(
+      @PathVariable int id,
+      @RequestBody RegistrationModel registration) {
+    try {
+      return new ResponseEntity<>(registrationService.updateRegistration(id, registration), HttpStatus.OK);
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+    }
+  }
+
+  @DeleteMapping("/destroy/{id}")
+  public ResponseEntity<Void> apagarInscricao(@PathVariable int id) {
+    try {
+      boolean deleted = registrationService.deleteRegistration(id);
+      if (deleted) {
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      } else {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      }
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+  }
 }

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Controller/RegistrationController.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Controller/RegistrationController.java
@@ -1,0 +1,10 @@
+package codeplac.codeplac.Controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/登记")
+public class RegistrationController {
+
+}

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Controller/TicketController.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Controller/TicketController.java
@@ -1,0 +1,70 @@
+package codeplac.codeplac.Controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import codeplac.codeplac.Exception.Excecao;
+import codeplac.codeplac.Model.TicketModel;
+import codeplac.codeplac.Service.TicketService;
+
+@RestController
+@RequestMapping("/ticket")
+public class TicketController {
+
+  @Autowired
+  TicketService ticketService;
+
+  @PostMapping("/generate")
+  public ResponseEntity<TicketModel> criarTicket(@RequestBody TicketModel ticket) {
+    return new ResponseEntity<>(ticketService.createTicket(ticket), HttpStatus.CREATED);
+  }
+
+  @GetMapping("/list")
+  public ResponseEntity<List<TicketModel>> listarTickets() {
+    return new ResponseEntity<>(ticketService.getAllTickets(), HttpStatus.OK);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<TicketModel> obterTicket(@PathVariable int id) {
+    try {
+      return new ResponseEntity<>(ticketService.getTicketById(id), HttpStatus.OK);
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+    }
+  }
+
+  @PutMapping("/modify/{id}")
+  public ResponseEntity<TicketModel> modificarTicket(@PathVariable int id, @RequestBody TicketModel ticket) {
+    try {
+      return new ResponseEntity<>(ticketService.updateTicket(id, ticket), HttpStatus.OK);
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage(), e);
+    }
+  }
+
+  @DeleteMapping("/destroy/{id}")
+  public ResponseEntity<Void> apagarTicket(@PathVariable int id) {
+    try {
+      boolean deleted = ticketService.deleteTicket(id);
+      if (deleted) {
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+      } else {
+        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+      }
+    } catch (Excecao e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getMessage(), e);
+    }
+  }
+}

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Controller/UsersController.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Controller/UsersController.java
@@ -29,7 +29,7 @@ public class UsersController {
         }
     }
 
-    @GetMapping("/listar")
+    @GetMapping("/list")
     public ResponseEntity<List<UsersModel>> listarUsuarios() {
         List<UsersModel> users = usersService.getAllUsers();
         return new ResponseEntity<>(users, HttpStatus.OK);
@@ -45,7 +45,7 @@ public class UsersController {
         }
     }
 
-    @PutMapping("/modificar/{matricula}")
+    @PutMapping("/modify/{matricula}")
     public ResponseEntity<UsersModel> modificarUsuario(@PathVariable int matricula, @RequestBody UsersModel user) {
         try {
             UsersModel updatedUser = usersService.updateUser(matricula, user);
@@ -55,7 +55,7 @@ public class UsersController {
         }
     }
 
-    @DeleteMapping("/apagar/{matricula}")
+    @DeleteMapping("/destroy/{matricula}")
     public ResponseEntity<Void> apagarUsuario(@PathVariable int matricula) {
         try {
             boolean deleted = usersService.deleteUser(matricula);

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Service/RegistrationService.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Service/RegistrationService.java
@@ -1,0 +1,54 @@
+package codeplac.codeplac.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import codeplac.codeplac.Exception.Excecao;
+import codeplac.codeplac.Model.RegistrationModel;
+import codeplac.codeplac.Repository.RegistrationRepository;
+
+@Service
+public class RegistrationService {
+
+  @Autowired
+  private RegistrationRepository registrationRepository;
+
+  public RegistrationModel createRegistration(RegistrationModel registrationModel) {
+    return registrationRepository.save(registrationModel);
+  }
+
+  public List<RegistrationModel> getAllRegistrations() {
+    return registrationRepository.findAll();
+  }
+
+  public RegistrationModel getRegistrationById(int id) throws Excecao {
+    Optional<RegistrationModel> registration = registrationRepository.findById(id);
+    if (registration.isPresent()) {
+      return registration.get();
+    }
+
+    throw new Excecao("Inscrição não encontrado com id: " + id);
+  }
+
+  public RegistrationModel updateRegistration(int id, RegistrationModel registration) throws Excecao {
+    if (registrationRepository.existsById(id)) {
+      registration.setCodigo_grupo(registration.getCodigo_grupo());
+      registration.setEvento(registration.getEvento());
+      registration.setUsuario(registration.getUsuario());
+      return registrationRepository.save(registration);
+    } else {
+      throw new Excecao("Inscrição não encontrado com id: " + id);
+    }
+  }
+
+  public boolean deleteRegistration(int id) throws Excecao {
+    if (registrationRepository.existsById(id)) {
+      registrationRepository.deleteById(id);
+    }
+
+    throw new Excecao("Inscrição não encontrado com id: " + id);
+  }
+}

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Service/TicketService.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Service/TicketService.java
@@ -1,0 +1,53 @@
+package codeplac.codeplac.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import codeplac.codeplac.Exception.Excecao;
+import codeplac.codeplac.Model.TicketModel;
+import codeplac.codeplac.Repository.TicketRepository;
+
+@Service
+public class TicketService {
+
+  @Autowired
+  private TicketRepository ticketRepository;
+
+  public TicketModel createTicket(TicketModel ticketModel) {
+    return ticketRepository.save(ticketModel);
+  }
+
+  public List<TicketModel> getAllTickets() {
+    return ticketRepository.findAll();
+  }
+
+  public TicketModel getTicketById(int id) throws Excecao {
+    Optional<TicketModel> ticket = ticketRepository.findById(id);
+    if (ticket.isPresent()) {
+      return ticket.get();
+    }
+
+    throw new Excecao("Ticket não encontrado com id: " + id);
+  }
+
+  public TicketModel updateTicket(int id, TicketModel ticket) throws Excecao {
+    if (ticketRepository.existsById(id)) {
+      ticket.setEvento(ticket.getEvento());
+      ticket.setValidado(ticket.getValidado());
+      return ticketRepository.save(ticket);
+    } else {
+      throw new Excecao("Ticket não encontrado com id: " + id);
+    }
+  }
+
+  public boolean deleteTicket(int id) throws Excecao {
+    if (ticketRepository.existsById(id)) {
+      ticketRepository.deleteById(id);
+    }
+
+    throw new Excecao("Ticket não encontrado com id: " + id);
+  }
+}

--- a/backend/codeplac/src/main/java/codeplac/codeplac/Service/UsersService.java
+++ b/backend/codeplac/src/main/java/codeplac/codeplac/Service/UsersService.java
@@ -48,19 +48,19 @@ public class UsersService {
         }
     }
 
-    public boolean deleteUser(int matricula) throws Excecao {
+    public UsersModel updateUser(int matricula, UsersModel user) throws Excecao {
         if (usersRepository.existsById(matricula)) {
-            usersRepository.deleteById(matricula);
-            return true;
+            user.setMatricula(matricula);
+            return usersRepository.save(user);
         } else {
             throw new Excecao("Usuário não encontrado com matrícula: " + matricula);
         }
     }
 
-    public UsersModel updateUser(int matricula, UsersModel user) throws Excecao {
+    public boolean deleteUser(int matricula) throws Excecao {
         if (usersRepository.existsById(matricula)) {
-            user.setMatricula(matricula);
-            return usersRepository.save(user);
+            usersRepository.deleteById(matricula);
+            return true;
         } else {
             throw new Excecao("Usuário não encontrado com matrícula: " + matricula);
         }


### PR DESCRIPTION
## Resumo
Este PR implementa o service e o controller para o model Registration (tabela Inscrição). Essas mudanças permitem a manipulação completa de criação, leitura, atualização e exclusão de uma inscrição para um evento.

## Funcionalidades implementadas
- CRUD completo para Registration.
- Manipulação de erros e retorno de mensagens apropriadas.

## Instruções para testes
1. Verifique se o servidor está em execução.
2. Teste as seguintes rotas na API:
   - `POST /registration/create` para criar uma nova inscrição.
   - `GET /registration/list` para listar todas as inscrições.
   - `GET /registration/:id` para buscar uma inscrição específica.
   - `PUT /registration/modify/:id` para atualizar uma inscrição existente.
   - `DELETE /registration/destroy/:id` para deletar uma inscrição.